### PR TITLE
Allow pass options to default parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,20 @@
 'use strict';
 
 var htmlparser = require('htmlparser2');
+var isObject = require('isobject');
+
+/**
+ * @see https://github.com/fb55/htmlparser2/wiki/Parser-options
+ */
+var defaultOptions = {lowerCaseTags: false};
 
 /**
  * Parse html to PostHTMLTree
  * @param  {String} html
- * @return {Object}
+ * @param  {Object} [options=defaultOptions]
+ * @return {PostHTMLTree}
  */
-module.exports = function postHTMLParser(html) {
+function postHTMLParser(html, options) {
     var bufArray = [],
         results = [];
 
@@ -67,10 +74,30 @@ module.exports = function postHTMLParser(html) {
             last.content || (last.content = []);
             last.content.push(text);
         }
-    }, {lowerCaseTags: false});
+    }, options || defaultOptions);
 
     parser.write(html);
     parser.end();
 
     return results;
-};
+}
+
+function parserWrapper() {
+    var option;
+
+    function parser(html) {
+        var opt = option || defaultOptions;
+        return postHTMLParser(html, opt);
+    }
+
+    if (arguments.length === 1 && isObject(arguments[0])) {
+        option = arguments[0];
+        return parser;
+    }
+
+    option = arguments[1];
+    return parser(arguments[0]);
+}
+
+module.exports = parserWrapper;
+module.exports.defaultOptions = defaultOptions;

--- a/package.json
+++ b/package.json
@@ -25,13 +25,17 @@
   },
   "homepage": "https://github.com/posthtml/posthtml-parser#readme",
   "dependencies": {
-    "htmlparser2": "^3.8.3"
+    "htmlparser2": "^3.8.3",
+    "isobject": "^2.1.0"
   },
   "devDependencies": {
     "chai": "^3.3.0",
     "istanbul": "^0.4.0",
     "jscs": "^2.3.5",
     "jshint": "^2.8.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "rewire": "^2.5.2",
+    "sinon": "^1.17.4",
+    "sinon-chai": "^2.8.0"
   }
 }


### PR DESCRIPTION
This allows to override posthtml-parser default options (which is actually [htmlparser2 parser options](https://github.com/fb55/htmlparser2/wiki/Parser-options)) and decrease pain when working [with SVG](https://github.com/posthtml/posthtml/issues/146).