### PR TITLE
Disable lowerCaseAttributeNames option by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var isObject = require('isobject');
 /**
  * @see https://github.com/fb55/htmlparser2/wiki/Parser-options
  */
-var defaultOptions = {lowerCaseTags: false};
+var defaultOptions = {lowerCaseTags: false, lowerCaseAttributeNames: false};
 
 /**
  * Parse html to PostHTMLTree


### PR DESCRIPTION
### Source

https://github.com/mrmlnc/vscode-attrs-sorter/issues/29

### Documentation

https://github.com/fb55/htmlparser2/wiki/Parser-options#option-lowercaseattributenames

### Description

IMHO, should be disabled by default.

```html
<a routerLink="/home">Home</a>
```

#### Before

```js
// ------------------------ \/
[ { tag: 'a', attrs: { routerlink: '/home' }, content: [ 'Home' ] },
  options: {},
  processor: PostHTML { version: '0.9.2', name: 'posthtml', plugins: [ [Function] ] },

  walk: [Function: walk],
  match: [Function: match] ]
```

#### After

```js
// ------------------------ \/
[ { tag: 'a', attrs: { routerLink: '/home' }, content: [ 'Home' ] },
  options: {},
  processor: PostHTML { version: '0.9.2', name: 'posthtml', plugins: [ [Function] ] },

  walk: [Function: walk],
  match: [Function: match] ]
```

/cc @voischev @michael-ciniawsky 
