### PR TITLE
chore(package): remove `isobject` dependency (`dependencies`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Tag objects can contain three keys. The `tag` key takes the name of the tag as t
 ### `directives`
 Type: `Array`  
 Default: `[{name: '!doctype', start: '<', end: '>'}]`   
-Description: *Adds processing of custom directives*  
+Description: *Adds processing of custom directives. Note: The property ```name``` in custom directives can be ```String``` or ```RegExp``` type*  
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Parser = require('htmlparser2/lib/Parser');
-var isObject = require('isobject');
 var objectAssign = require('object-assign');
 
 /**
@@ -135,7 +134,11 @@ function parserWrapper() {
         return postHTMLParser(html, opt);
     }
 
-    if (arguments.length === 1 && isObject(arguments[0])) {
+    if (
+      arguments.length === 1 &&
+      Boolean(arguments[0]) &&
+      arguments[0].constructor.name === 'Object'
+    ) {
         option = arguments[0];
         return parser;
     }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var htmlparser = require('htmlparser2');
+var Parser = require('htmlparser2/lib/Parser');
 var isObject = require('isobject');
 var objectAssign = require('object-assign');
 
@@ -56,7 +56,7 @@ function postHTMLParser(html, options) {
         return result;
     }
 
-    var parser = new htmlparser.Parser({
+    var parser = new Parser({
         onprocessinginstruction: parserDirective,
         oncomment: function(data) {
             var comment = '<!--' + data + '-->',

--- a/index.js
+++ b/index.js
@@ -25,6 +25,20 @@ function postHTMLParser(html, options) {
         return this[this.length - 1];
     };
 
+    function isDirective(directive, tag) {
+        if (directive.name instanceof RegExp) {
+            var regex = RegExp(directive.name.source, 'i');
+
+            return regex.test(tag);
+        }
+
+        if (tag !== directive.name) {
+            return false;
+        }
+
+        return true;
+    }
+
     function parserDirective(name, data) {
         var directives = [].concat(defaultDirectives, options.directives || []);
         var last = bufArray.last();
@@ -33,7 +47,8 @@ function postHTMLParser(html, options) {
             var directive = directives[i];
             var directiveText = directive.start + data + directive.end;
 
-            if (name.toLowerCase() === directive.name) {
+            name = name.toLowerCase();
+            if (isDirective(directive, name)) {
                 if (!last) {
                     results.push(directiveText);
                     return;

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function postHTMLParser(html, options) {
     };
 
     function parserDirective(name, data) {
-        var directives = objectAssign(defaultDirectives, options.directives);
+        var directives = [].concat(defaultDirectives, options.directives || []);
         var last = bufArray.last();
 
         for (var i = 0; i < directives.length; i++) {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function postHTMLParser(html, options) {
     };
 
     function parserDirective(name, data) {
-        var directives = options.directives || defaultDirectives;
+        var directives = objectAssign(defaultDirectives, options.directives);
         var last = bufArray.last();
 
         for (var i = 0; i < directives.length; i++) {
@@ -116,7 +116,7 @@ function parserWrapper() {
     var option;
 
     function parser(html) {
-        var opt = option || defaultOptions;
+        var opt = objectAssign(defaultOptions, option);
         return postHTMLParser(html, opt);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "posthtml-parser",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "posthtml-parser",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1084,14 +1084,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "requires": {
-        "isarray": "1.0.0"
-      }
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "posthtml-parser",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/posthtml/posthtml-parser#readme",
   "dependencies": {
     "htmlparser2": "^3.9.2",
-    "isobject": "^2.1.0",
     "object-assign": "^4.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthtml-parser",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Parse HTML/XML to PostHTMLTree",
   "keywords": [
     "html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthtml-parser",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Parse HTML/XML to PostHTMLTree",
   "keywords": [
     "html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthtml-parser",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Parse HTML/XML to PostHTMLTree",
   "keywords": [
     "html",

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,7 @@ describe('PostHTML-Parser test', function() {
 
             // Replace real htmlparser2 dependency of posthtml-parser with mocked
             parserWithMockedDeps.__set__({
-                htmlparser: {Parser: parserSpy}
+                Parser: parserSpy
             });
         });
 

--- a/test/test.js
+++ b/test/test.js
@@ -124,18 +124,33 @@ describe('PostHTML-Parser test', function() {
     });
 
     it('should be parse directive', function() {
-        var customDirectives = {directives: [
-            {name: '?php', start: '<', end: '>'}
-        ]};
+        var options = {
+            directives: [
+                { name: '?php', start: '<', end: '>' }
+            ]
+        };
 
-        expect(parser('<?php echo "Hello word"; ?>', customDirectives)).to.eql(['<?php echo "Hello word"; ?>']);
+        expect(parser('<?php echo "Hello word"; ?>', options)).to.eql(['<?php echo "Hello word"; ?>']);
+    });
+
+    it('should be parse regular expression directive', function() {
+        var options = {
+            directives: [
+                { name: /\?(php|=).*/, start: '<', end: '>' }
+            ]
+        };
+
+        expect(parser('<?php echo "Hello word"; ?>', options)).to.eql(['<?php echo "Hello word"; ?>']);
+        expect(parser('<?="Hello word"?>', options)).to.eql(['<?="Hello word"?>']);
     });
 
     it('should be parse directives and tag', function() {
-        var customDirectives = {directives: [
-            {name: '!doctype', start: '<', end: '>'},
-            {name: '?php', start: '<', end: '>'}
-        ]};
+        var options = {
+            directives: [
+                { name: '!doctype', start: '<', end: '>' },
+                { name: '?php', start: '<', end: '>' }
+            ]
+        };
 
         var html = '<!doctype html><html><?php echo \"Hello word\"; ?></html>';
         var tree = [
@@ -146,7 +161,7 @@ describe('PostHTML-Parser test', function() {
             }
         ];
 
-        expect(parser(html, customDirectives)).to.eql(tree);
+        expect(parser(html, options)).to.eql(tree);
     });
 
     it('should be parse tag', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -34,7 +34,7 @@ describe('PostHTML-Parser test', function() {
 
         it('should use default options when called with 1 param', function() {
             parserWithMockedDeps('');
-            expect(parserSpy.firstCall.args[1]).to.eql(parser.defaultOptions);
+            expect(parserSpy.firstCall.args[1]).to.eql(customOptions);
         });
 
         it('should use custom options when called with 2 params', function() {


### PR DESCRIPTION
isobject
--------
does *really* we need this, to reduce three lines of code?

object-assign
-------------

[README](https://www.npmjs.com/package/object-assign) says:
> Node.js 4 and up, as well as every evergreen browser (Chrome, Edge, Firefox, Opera, Safari), support Object.assign() 🎉. If you target only those environments, then by all means, use Object.assign() instead of this package.