### PR TITLE
feat(index): add support for `{RegExp}` directives (`options.directives`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Tag objects can contain three keys. The `tag` key takes the name of the tag as t
 ### `directives`
 Type: `Array`  
 Default: `[{name: '!doctype', start: '<', end: '>'}]`   
-Description: *Adds processing of custom directives*  
+Description: *Adds processing of custom directives. Note: The property ```name``` in custom directives can be ```String``` or ```RegExp``` type*  
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -25,6 +25,20 @@ function postHTMLParser(html, options) {
         return this[this.length - 1];
     };
 
+    function isDirective(directive, tag) {
+        if (directive.name instanceof RegExp) {
+            var regex = RegExp(directive.name, 'i');
+
+            return regex.test(tag);
+        }
+
+        if (tag !== directive.name) {
+            return false;
+        }
+
+        return true;
+    }
+
     function parserDirective(name, data) {
         var directives = objectAssign(defaultDirectives, options.directives);
         var last = bufArray.last();
@@ -33,18 +47,9 @@ function postHTMLParser(html, options) {
         for (var i = 0; i < directives.length; i++) {
             var directive = directives[i];
             var directiveText = directive.start + data + directive.end;
-            var isDirective = false;
 
             tagName = name.toLowerCase();
-            if ((directive.name instanceof RegExp) && directive.name.test(tagName)) {
-                isDirective = true;
-            }
-
-            if (tagName === directive.name) {
-                isDirective = true;
-            }
-
-            if (isDirective) {
+            if (isDirective(directive, tagName)) {
                 if (!last) {
                     results.push(directiveText);
                     return;

--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ function postHTMLParser(html, options) {
             tagName = name.toLowerCase();
             if ((directive.name instanceof RegExp) && directive.name.test(tagName)) {
                 isDirective = true;
-            } else if (tagName === directive.name) {
+            }
+
+            if (tagName === directive.name) {
                 isDirective = true;
             }
 

--- a/index.js
+++ b/index.js
@@ -43,13 +43,12 @@ function postHTMLParser(html, options) {
         var directives = [].concat(defaultDirectives, options.directives || []);
         var last = bufArray.last();
 
-        var tagName;
         for (var i = 0; i < directives.length; i++) {
             var directive = directives[i];
             var directiveText = directive.start + data + directive.end;
 
-            tagName = name.toLowerCase();
-            if (isDirective(directive, tagName)) {
+            name = name.toLowerCase();
+            if (isDirective(directive, name)) {
                 if (!last) {
                     results.push(directiveText);
                     return;

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function postHTMLParser(html, options) {
 
     function isDirective(directive, tag) {
         if (directive.name instanceof RegExp) {
-            var regex = RegExp(directive.name, 'i');
+            var regex = RegExp(directive.name.source, 'i');
 
             return regex.test(tag);
         }

--- a/index.js
+++ b/index.js
@@ -29,11 +29,20 @@ function postHTMLParser(html, options) {
         var directives = options.directives || defaultDirectives;
         var last = bufArray.last();
 
+        var tagName;
         for (var i = 0; i < directives.length; i++) {
             var directive = directives[i];
             var directiveText = directive.start + data + directive.end;
+            var isDirective = false;
 
-            if (name.toLowerCase() === directive.name) {
+            tagName = name.toLowerCase();
+            if ((directive.name instanceof RegExp) && directive.name.test(tagName)) {
+                isDirective = true;
+            } else if (tagName === directive.name) {
+                isDirective = true;
+            }
+
+            if (isDirective) {
                 if (!last) {
                     results.push(directiveText);
                     return;

--- a/test/test.js
+++ b/test/test.js
@@ -124,27 +124,33 @@ describe('PostHTML-Parser test', function() {
     });
 
     it('should be parse directive', function() {
-        var customDirectives = {directives: [
-            {name: '?php', start: '<', end: '>'}
-        ]};
+        var options = {
+            directives: [
+                { name: '?php', start: '<', end: '>' }
+            ]
+        };
 
-        expect(parser('<?php echo "Hello word"; ?>', customDirectives)).to.eql(['<?php echo "Hello word"; ?>']);
+        expect(parser('<?php echo "Hello word"; ?>', options)).to.eql(['<?php echo "Hello word"; ?>']);
     });
 
     it('should be parse regular expression directive', function() {
-        var customDirectives = {directives: [
-            {name: /\?(php|=).*/, start: '<', end: '>'}
-        ]};
+        var options = {
+            directives: [
+                { name: /\?(php|=).*/, start: '<', end: '>' }
+            ]
+        };
 
-        expect(parser('<?php echo "Hello word"; ?>', customDirectives)).to.eql(['<?php echo "Hello word"; ?>']);
-        expect(parser('<?="Hello word"?>', customDirectives)).to.eql(['<?="Hello word"?>']);
+        expect(parser('<?php echo "Hello word"; ?>', options)).to.eql(['<?php echo "Hello word"; ?>']);
+        expect(parser('<?="Hello word"?>', options)).to.eql(['<?="Hello word"?>']);
     });
 
     it('should be parse directives and tag', function() {
-        var customDirectives = {directives: [
-            {name: '!doctype', start: '<', end: '>'},
-            {name: '?php', start: '<', end: '>'}
-        ]};
+        var options = {
+            directives: [
+                { name: '!doctype', start: '<', end: '>' },
+                { name: '?php', start: '<', end: '>' }
+            ]
+        };
 
         var html = '<!doctype html><html><?php echo \"Hello word\"; ?></html>';
         var tree = [
@@ -155,7 +161,7 @@ describe('PostHTML-Parser test', function() {
             }
         ];
 
-        expect(parser(html, customDirectives)).to.eql(tree);
+        expect(parser(html, options)).to.eql(tree);
     });
 
     it('should be parse tag', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -131,6 +131,15 @@ describe('PostHTML-Parser test', function() {
         expect(parser('<?php echo "Hello word"; ?>', customDirectives)).to.eql(['<?php echo "Hello word"; ?>']);
     });
 
+    it('should be parse regular expression directive', function() {
+        var customDirectives = {directives: [
+            {name: /\?(php|=).*/, start: '<', end: '>'}
+        ]};
+
+        expect(parser('<?php echo "Hello word"; ?>', customDirectives)).to.eql(['<?php echo "Hello word"; ?>']);
+        expect(parser('<?="Hello word"?>', customDirectives)).to.eql(['<?="Hello word"?>']);
+    });
+
     it('should be parse directives and tag', function() {
         var customDirectives = {directives: [
             {name: '!doctype', start: '<', end: '>'},


### PR DESCRIPTION
Example:
The custom directive ```{name: /\?(php|=).*/, start: '<', end: '>'}``` will match any directive with ```<?php ?>``` or ```<?= ?>``` pattern.

**Note:**
I thought that this commit will solve https://github.com/posthtml/posthtml-parser/issues/26#issuecomment-358201603 if we use regular expression directive started with ```<%``` but after I checked the library, I found that any tag started with ```%``` for example ```<%=name%>``` will be treated as a tag by the library, so this tag will never touch ```onprocessinginstruction``` event. So this is an exception.