### PR TITLE
fix: correctly parse text content after comments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ const parser = (html: string, options: Options = {}): Node[] => {
     if (typeof last === 'object') {
       if (last.content && last.content.length > 0) {
         const lastContentNode = last.content[last.content.length - 1];
-        if (typeof lastContentNode === 'string') {
+        if (typeof lastContentNode === 'string' && !lastContentNode.startsWith('<!--')) {
           last.content[last.content.length - 1] = `${lastContentNode}${text}`;
           return;
         }

--- a/test/test-core.spec.ts
+++ b/test/test-core.spec.ts
@@ -68,9 +68,27 @@ test.skip('should be parse tag with object in attribute data escape', t => {
   t.deepEqual(tree, expected);
 });
 
-test('should be parse comment in content', t => {
+test('should be parse isolated comment', t => {
   const tree = parser('<div><!--comment--></div>');
   const expected = [{tag: 'div', content: ['<!--comment-->']}];
+  t.deepEqual(tree, expected);
+});
+
+test('should be parse comment before text content', t => {
+  const tree = parser('<div><!--comment-->Text after comment</div>');
+  const expected = [{tag: 'div', content: ['<!--comment-->', 'Text after comment']}];
+  t.deepEqual(tree, expected);
+});
+
+test('should be parse comment after text content', t => {
+  const tree = parser('<div>Text before comment.<!--comment--></div>');
+  const expected = [{tag: 'div', content: ['Text before comment.', '<!--comment-->']}];
+  t.deepEqual(tree, expected);
+});
+
+test('should be parse comment in the middle of text content', t => {
+  const tree = parser('<div>Text surrounding <!--comment--> a comment.</div>');
+  const expected = [{tag: 'div', content: ['Text surrounding ', '<!--comment-->', ' a comment.']}];
   t.deepEqual(tree, expected);
 });
 


### PR DESCRIPTION
This PR fixes a bug I discovered where text content that follows an HTML comment isn't parsed correctly.

## Bug

Input:
```html
<div>
  Text before a comment...
  <!--comment-->
  ...and some more text after it.
</div>
```

Expected:
```js
[
  {
    tag: "div",
    content: [
      "\n  Text before a comment...\n  ",
      "<!--comment-->",
      "\n  ...and some more text after it.\n",
    ],
  },
]
```

Actual:
```js
[
  {
    tag: "div",
    content: [
      "\n  Text before a comment...\n  ",
      "<!--comment-->\n  ...and some more text after it.\n", // bug: comment and text have been concatenated
    ],
  },
]
```

## Fix

The bug occurs in the `ontext()` function. When `last.contents` exists and its last element is a string, the text gets appended to that string. This is correct except for when that string is a comment, so I've simply added a check to see if the string starts with `"<!--"`. If it does, the text is appended to the contents array instead.

I've also added three new test cases that ensure text content near comments is parsed correctly.

