### PR TITLE
Add prepare script to package.json

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14]
+        node: [12, 14]
         os: [ubuntu-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "main": "dist",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "version": "conventional-changelog -i changelog.md -s -r 0 && git add changelog.md",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "build": "rm -rf dist && tsup src/*.ts --minify",
     "dev": "npm run build -- --watch",
     "test": "xo && c8 ava",
-    "pretest": "clinton"
+    "pretest": "clinton",
+    "prepare": "npm run build"
   },
   "keywords": [
     "html",


### PR DESCRIPTION
The `prepare` script is run automatically before `npm publish`, so having it run the build command might help to avoid issues like #61.

This only affects the workflow of package maintainers and not of end-users, so please feel free to reject this PR if you prefer a different method.