### PR TITLE
Decrease package size from `43.6 kB` to `11.1 kB`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "typescript": "^4.0.5",
     "xo": "^0.37.1"
   },
-  "types": "dist/index.d.ts"
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
Filter all development files from npm package.

```bash
npm pack --dry-run
```

from:

```
=== Tarball Contents ===
119B   .clintonrc.json
336B   .editorconfig
639B   .github/funding.yml
785B   .github/workflows/nodejs.yml
116B   .huskyrc
19B    .lintstagedrc
122B   ava.config.js
20.4kB changelog.md
504B   dist/chunk.T6SARJYH.js
819B   dist/index.d.ts
2.1kB  dist/index.js
384B   dist/location-tracker.d.ts
173B   dist/location-tracker.js
1.1kB  license
1.6kB  package.json
4.4kB  readme.md
9.6kB  test/test-core.spec.ts
176B   tsconfig.json
227B   xo.config.js
=== Tarball Details ===
package size:  11.9 kB
unpacked size: 43.6 kB
total files:   20
```

to:

```
=== Tarball Contents ===
504B  dist/chunk.T6SARJYH.js
819B  dist/index.d.ts
2.1kB dist/index.js
384B  dist/location-tracker.d.ts
173B  dist/location-tracker.js
1.1kB license
1.6kB package.json
4.4kB readme.md
=== Tarball Details ===
package size:  4.6 kB
unpacked size: 11.1 kB
total files:   8
```